### PR TITLE
feat(sfartist): brush color legend

### DIFF
--- a/src/client/src/components/sf-artist/BrushColorLabels.js
+++ b/src/client/src/components/sf-artist/BrushColorLabels.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+function BrushColorLabels({ connectedPlayers }) {
+  return (
+    <div>
+      <br/>
+      <h3>Here are your brush colors!</h3>
+      {
+      	connectedPlayers.filter(player => player.connected).map(player =>
+	      	<span key={player.id} style={{backgroundColor: 'white'}}>
+	        	<span style={{color: player.brushColor}}>●</span>
+	        	<span style={{color: 'black'}}>: {player.name} </span>
+	      	</span>
+	    	)
+      }
+    </div>
+  );
+}
+
+export default BrushColorLabels;

--- a/src/client/src/components/sf-artist/DrawingPhaseView.js
+++ b/src/client/src/components/sf-artist/DrawingPhaseView.js
@@ -105,7 +105,9 @@ function DrawingPhase() {
           ref={canvasRef}
         />
       </div>
-      <h2 className='text-center my-2'>{activePlayer?.name}'s turn</h2>
+      <h2 className='text-center my-2'>
+        <span style={{color: activePlayer?.brushColor}}>● </span>
+        {activePlayer?.name}'s turn</h2>
       {
         currPlayerIsActivePlayer &&
           <p>

--- a/src/client/src/components/sf-artist/SfArtistBoard.js
+++ b/src/client/src/components/sf-artist/SfArtistBoard.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
+import BrushColorLabels from './BrushColorLabels';
 import DisplaySubjectView from './DisplaySubjectView';
 import DrawingPhaseView from './DrawingPhaseView';
 import ExplainRulesView from './ExplainRulesView';
@@ -61,6 +62,10 @@ function SfArtistBoard() {
           }
           {
             gameState === GameEnd && <ResultsView />
+          }
+          {
+            [DrawingPhase, VotingPhase, GameEnd].includes(gameState) &&
+            <BrushColorLabels connectedPlayers={connectedPlayers}/>
           }
         </Col>
         <Col sm={4} md={3} className='main-panel text-center py-5'>


### PR DESCRIPTION
Added brush color legend and for current artist for SF artist. The legend is currently at the bottom of view in order to just call it once.
![image](https://user-images.githubusercontent.com/860410/97764878-56188f00-1acd-11eb-9da2-52cfba6a4619.png)
