### PR TITLE
fix(werewolf): mason/doppelganger role checks

### DIFF
--- a/TODO
+++ b/TODO
@@ -21,7 +21,6 @@ Option to randomize roles
 Option to randomize + x werewolves
 
 warnings when including:
-* only 1 mason
 * insomniac but no troublemaker/robber
 
 conditionally show rules based on which game you're playing

--- a/src/client/src/components/werewolf/ChoosingRolesView.js
+++ b/src/client/src/components/werewolf/ChoosingRolesView.js
@@ -19,18 +19,9 @@ import {
   socketSelector,
 } from '../../store/selectors';
 import {
-  ROLE_WEREWOLF,
-  ROLE_MINION,
   ROLE_MASON,
-  ROLE_SEER,
-  ROLE_ROBBER,
-  ROLE_TROUBLEMAKER,
-  ROLE_DRUNK,
-  ROLE_INSOMNIAC,
-  ROLE_HUNTER,
-  ROLE_VILLAGER,
   ROLE_DOPPELGANGER,
-  ROLE_TANNER,
+  WEREWOLF_CARD_IDS,
 } from '../../constants';
 
 function ChoosingRolesView() {
@@ -81,6 +72,10 @@ function ChoosingRolesView() {
       alert(`Please choose exactly ${numRolesToChoose} roles before continuing.`);
       return;
     }
+    if (roleIds.filter(x => WEREWOLF_CARD_IDS[x] === ROLE_MASON).length === 1) {
+      alert('Please include both masons if you want to play with that role!');
+      return;
+    }
     socket.emit('playerAction', { action: 'beginNighttime' });
   };
 
@@ -91,7 +86,7 @@ function ChoosingRolesView() {
       );
       return;
     }
-    if (toggledRoleId === ROLE_DOPPELGANGER) {
+    if (WEREWOLF_CARD_IDS[toggledRoleId] === ROLE_DOPPELGANGER) {
       alert('Please upgrade to premium to access the Doppelganger role by buying me a coffee.');
       return;
     }
@@ -127,6 +122,7 @@ function ChoosingRolesView() {
     return (
       <RoleCard
         id={id}
+        key={id}
         role={role}
         chooseMode={true}
         callback={onToggleRole}
@@ -199,23 +195,11 @@ function ChoosingRolesView() {
 
       <div className='gallery'>
         <CardDeck>
-          {renderRoleCard('werewolf1', ROLE_WEREWOLF)}
-          {renderRoleCard('werewolf2', ROLE_WEREWOLF)}
-          {renderRoleCard('werewolf3', ROLE_WEREWOLF)}
-          {renderRoleCard('minion', ROLE_MINION)}
-          {renderRoleCard('tanner', ROLE_TANNER)}
-          {renderRoleCard('mason1', ROLE_MASON)}
-          {renderRoleCard('mason2', ROLE_MASON)}
-          {renderRoleCard('seer', ROLE_SEER)}
-          {renderRoleCard('robber', ROLE_ROBBER)}
-          {renderRoleCard('troublemaker', ROLE_TROUBLEMAKER)}
-          {renderRoleCard('drunk', ROLE_DRUNK)}
-          {renderRoleCard('insomniac', ROLE_INSOMNIAC)}
-          {renderRoleCard('hunter', ROLE_HUNTER)}
-          {renderRoleCard('doppelganger', ROLE_DOPPELGANGER)}
-          {renderRoleCard('villager1', ROLE_VILLAGER)}
-          {renderRoleCard('villager2', ROLE_VILLAGER)}
-          {renderRoleCard('villager3', ROLE_VILLAGER)}
+          {
+            Object.keys(WEREWOLF_CARD_IDS).map(card_id =>
+              renderRoleCard(card_id, WEREWOLF_CARD_IDS[card_id])
+            )
+          }
         </CardDeck>
       </div>
       <div className={cx('fixed-header text-center', { show: showFixedHeader })}>

--- a/src/client/src/components/werewolf/MasonView.js
+++ b/src/client/src/components/werewolf/MasonView.js
@@ -38,7 +38,7 @@ function MasonView() {
           </div>
       }
       {
-        ready &&
+        ready && otherMason &&
           <em>Waiting for {otherMason.name} to end turn...</em>
       }
     </>

--- a/src/client/src/constants.js
+++ b/src/client/src/constants.js
@@ -59,6 +59,26 @@ export const ROLE_VILLAGER = 9;
 export const ROLE_DOPPELGANGER = 10;
 export const ROLE_TANNER = 11;
 
+export const WEREWOLF_CARD_IDS = {
+  'werewolf1': ROLE_WEREWOLF,
+  'werewolf2': ROLE_WEREWOLF,
+  'werewolf3': ROLE_WEREWOLF,
+  'minion': ROLE_MINION,
+  'tanner': ROLE_TANNER,
+  'mason1': ROLE_MASON,
+  'mason2': ROLE_MASON,
+  'seer': ROLE_SEER,
+  'robber': ROLE_ROBBER,
+  'troublemaker': ROLE_TROUBLEMAKER,
+  'drunk': ROLE_DRUNK,
+  'insomniac': ROLE_INSOMNIAC,
+  'hunter': ROLE_HUNTER,
+  'doppelganger': ROLE_DOPPELGANGER,
+  'villager1': ROLE_VILLAGER,
+  'villager2': ROLE_VILLAGER,
+  'villager3': ROLE_VILLAGER,
+};
+
 export const WEREWOLF_ROLE_LABELS = {
   [ROLE_WEREWOLF]: 'Werewolf',
   [ROLE_MINION]: 'Minion',


### PR DESCRIPTION
* check the card ID instead of role for doppelganger check
* alert if only 1 mason added