### PR TITLE
feat(voteresults): clarify voter/voted

### DIFF
--- a/src/client/src/components/common/VoteResults.js
+++ b/src/client/src/components/common/VoteResults.js
@@ -13,8 +13,9 @@ const renderVotedPlayerRow = (suspectPlayer, voterPlayers, isEliminated, renderS
 
   return (
     <ListGroup.Item key={suspectPlayer.id} variant={isEliminated ? 'danger' : ''}>
-      <h3>{shouldShowSkulls && '💀 '}{suspectPlayer.name}{shouldShowSkulls && ' 💀'}</h3>
       {voterPlayers.map(voter => <Badge key={voter.id}>{voter.name}</Badge>)}
+      <span> voted for:</span>
+      <h3>{shouldShowSkulls && '💀 '}{suspectPlayer.name}{shouldShowSkulls && ' 💀'}</h3>
     </ListGroup.Item>
   );
 };

--- a/src/client/src/components/werewolf/VoteResults.js
+++ b/src/client/src/components/werewolf/VoteResults.js
@@ -33,8 +33,9 @@ const getTeam = role => {
 const renderVotedPlayerRow = (suspectPlayer, voterPlayers, isEliminated) => {
   return (
     <ListGroup.Item variant={isEliminated ? 'danger' : ''}>
+      {voterPlayers.map(voter => <Badge key={voter.id}>{voter.name}</Badge>)}
+      <span> voted for:</span>
       <h3>{isEliminated && '💀 '}{suspectPlayer.name}{isEliminated && ' 💀'}</h3>
-      {voterPlayers.map(voter => <Badge>{voter.name}</Badge>)}
     </ListGroup.Item>
   );
 };


### PR DESCRIPTION
What I actually wanted to do was import `renderVotedPlayerRow` from common/VoteResults and reuse it in werewolf/VoteResults...

![image](https://user-images.githubusercontent.com/860410/97790825-4bbbcb00-1b89-11eb-9894-f27dde032172.png)
